### PR TITLE
페이지 게시글이 10개씩 나눠떨어질떄 발생하는 오류 수정

### DIFF
--- a/post/page.go
+++ b/post/page.go
@@ -23,7 +23,11 @@ func NewPageInfo() *PageInfo {
 
 func SetPageInfo(pageInfo *PageInfo) error {
 	pageInfo.Start = pageInfo.Current
-	pageInfo.End = (int(pageInfo.Total) / pageInfo.Max) + 1
+	pageInfo.End = (int(pageInfo.Total) / pageInfo.Max)
+
+	if int(pageInfo.Total)%pageInfo.Max != 0 {
+		pageInfo.End += 1
+	}
 
 	if pageInfo.Current > 1 {
 		pageInfo.Prev = pageInfo.Current - 1


### PR DESCRIPTION
1. 페이지 게시글이 10개씩 나눠떨어질떄 인덱스가 하나씩 더 생성되는 문제 수정